### PR TITLE
Completed all blog routes. Added a route to get past admins

### DIFF
--- a/src/controllers/admin/blogs.ts
+++ b/src/controllers/admin/blogs.ts
@@ -1,0 +1,195 @@
+import { prismaClient } from "@/main"
+import { Request, Response } from "express";
+import { z } from "zod";
+import { UpdateBlogValidator } from "@/types/blog";
+
+export const GetBlogByIdHandler = async (req : Request, res : Response) => {
+    const blogId = z.string().cuid().safeParse(req.params.blogId)
+    if(!blogId.success){
+        return res.status(400).json({
+            message: "Invalid Blog Id provided"
+        });
+    }
+
+    try{
+        const blog = await prismaClient.blogs.findFirst({
+            where:{
+                id : blogId.data
+            },
+            select:{
+                id : true,
+                title : true,
+                blurb : true,
+                content : true,
+                author : true,
+                tags : true,
+                status : true,
+                publishedOn : true
+            }
+        })
+        return res.status(200).json({
+            blog
+        });
+    }
+    catch(e){
+        return res.status(500).json({
+            message:"Internal Server Error! Please try again later."
+        });
+    }
+}
+
+export const GetAllBlogsHandlerForAdmin = async (_ : Request, res : Response) => {
+    try {
+        const blogs = await prismaClient.blogs.findMany({
+            select : {
+                id : true,
+                title : true,
+                blurb : true,
+                content : true,
+                author : true,
+                tags : true,
+                status : true,
+                publishedOn : true
+            }
+        });
+        return res.status(200).json({
+            blogs
+        });
+    }
+    catch(e){
+        return res.status(500).json({
+            message:"Internal Server Error! Please try again later."
+        });
+    }
+}
+
+export const UpdateBlogHandler = async (req : Request, res : Response) => {
+    const validateBlog = UpdateBlogValidator.safeParse(req.body);
+    if(!validateBlog.success){
+        return res.status(400).json({
+            message: "Invalid Blog data provided!"
+          });
+    }
+
+    const blogId = z.string().cuid().safeParse(req.params.blogId)
+    if(!blogId.success){
+        return res.status(400).json({
+            message: "Invalid Blog Id provided"
+        });
+    }
+
+    const blog = await prismaClient.blogs.findFirst({
+        where:{
+            id : blogId.data
+        }
+    })
+    if (!blog) {
+        return res.status(404).json({
+            message: "Blog not found!"
+          })
+    }
+    
+    try {
+        const blog = await prismaClient.$transaction(async (tx) => {
+            const updatedBlog = await tx.blogs.update({
+                where:{
+                    id : blogId.data
+                },
+                data:{
+                    title : validateBlog.data.title,
+                    displayURL : validateBlog.data.displayURL,
+                    blurb : validateBlog.data.blurb,
+                    content : validateBlog.data.content,
+                    author : validateBlog.data.author,
+                    tags : validateBlog.data.tags,
+                    status : validateBlog.data.status,
+                    publishedOn : validateBlog.data.publishedOn
+                }
+            });
+            return updatedBlog;
+        });
+        return res.status(200).json({
+            blog
+        });
+    }
+    catch(e){
+        return res.status(500).json({
+            message: "Internal Server Error! Please try again later."
+          });
+    }
+}
+
+export const DeleteBlogHandler = async (req : Request, res : Response) => {
+    const blogId = z.string().cuid().safeParse(req.params.blogId)
+    if(!blogId.success){
+        return res.status(400).json({
+            message: "Invalid Blog Id provided"
+        });
+    }
+
+    const blog = await prismaClient.blogs.findFirst({
+        where:{
+            id : blogId.data
+        }
+    })
+    if (!blog) {
+        return res.status(404).json({
+            message: "Blog not found!"
+          })
+    }
+
+    try{
+        const blog = await prismaClient.$transaction(async (tx) => {
+            const deletedBlog = await tx.blogs.delete({
+                where:{
+                    id : blogId.data
+                }
+            })
+        })
+        return res.status(200).json({
+            message : "Blog deleted successfully"
+        })
+    }
+    catch(e){
+        return res.status(500).json({
+            message: "Internal Server Error! Please try again later."
+          });
+    }
+}
+
+export const ChangeStatusOfBlog = async (req : Request, res : Response) => {
+    const validStatus = z.enum(["Draft", "Published"]).safeParse(req.body.status);
+    if(!validStatus.success){
+        return res.status(400).json({
+            message: "Invalid Blog data provided!"
+          });
+    }
+
+    const blogId = z.string().cuid().safeParse(req.params.blogId)
+    if(!blogId.success){
+        return res.status(400).json({
+            message: "Invalid Blog Id provided"
+        });
+    }
+
+    try{
+        const blog = await prismaClient.$transaction(async (tx) => {
+            const changeStatusBlog = await tx.blogs.update({
+                where:{
+                    id : blogId.data
+                },
+                data:{
+                    status : validStatus.data
+                }
+            })
+        });
+        return res.status(200).json({
+            message : "Status updated successfully"
+        });
+    }
+    catch(e){
+        return res.status(500).json({
+            message: "Internal Server Error! Please try again later."
+          });
+    }
+}

--- a/src/controllers/admin/office.ts
+++ b/src/controllers/admin/office.ts
@@ -131,13 +131,11 @@ export const CreateAdminHandler = async (req: Request, res: Response) => {
       // Send email to new admin
       sendAdminPassword(newAdmin.firstName, newAdmin.email, password);
 
-      return newAdmin;
     });
 
     // Return success response
     return res.status(201).json({
       message: "Admin created successfully",
-      admin: admins,
     });
 
   } catch (e) {
@@ -157,3 +155,29 @@ export const CreateAdminHandler = async (req: Request, res: Response) => {
     }
   }
 };
+
+export const GetPastAdminHandler = async (_ : Request, res : Response) => {
+  try {
+    const pastAdmins = await prismaClient.admin.findMany({
+      where : {
+        isActive : false
+      },
+      select : {
+        id : true,
+        firstName : true,
+        lastName : true,
+        email : true,
+        department : true,
+        role : true
+      }
+    });
+    return res.status(200).json({
+      pastAdmins
+    })
+  }
+  catch (e) {
+    return res.status(500).json({
+      message : "Internal Server Error! Please try again later."
+    });
+  }
+}

--- a/src/controllers/user/blog.ts
+++ b/src/controllers/user/blog.ts
@@ -1,0 +1,68 @@
+import { prismaClient } from "@/main"
+import { Request, Response } from "express";
+import { z } from "zod";
+import { UpdateBlogValidator } from "@/types/blog";
+
+export const GetAllBlogsHandlerForUser = async (_ : Request, res : Response) => {
+    try {
+        const blogs = await prismaClient.blogs.findMany({
+            select : {
+                id : true,
+                title : true,
+                displayURL : true,
+                blurb : true,
+                content : true,
+                author : true,
+                tags : true,
+                status : true,
+                publishedOn : true
+            }
+        });
+        return res.status(200).json({
+            blogs
+        });
+    }
+    catch(e){
+        return res.status(500).json({
+            message:"Internal Server Error! Please try again later."
+        });
+    }
+}
+
+export const GetBlogByIdHandler = async (req : Request, res : Response) => {
+    const blogId = z.string().cuid().safeParse(req.params.blogId)
+    if(!blogId.success){
+        return res.status(400).json({
+            message: "Invalid Blog Id provided"
+        });
+    }
+
+    try{
+        const blog = await prismaClient.blogs.findFirst({
+            where:{
+                id : blogId.data
+            },
+            select:{
+                id : true,
+                title : true,
+                blurb : true,
+                content : true,
+                author : true,
+                tags : true,
+                status : true,
+                publishedOn : true
+            }
+        })
+        return res.status(200).json({
+            blog
+        });
+    }
+    catch(e){
+        return res.status(500).json({
+            message:"Internal Server Error! Please try again later."
+        });
+    }
+}
+
+
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import helmet from "helmet";
 import generateKey from "./encryption/generate";
 
 import adminRouter from "@/routes/admin.routes"
+import generalRouter from "@/routes/user.routes"
 // import eventRouter from "@/routes/event.routes"
 
 import { PrismaClient } from "@prisma/client";
@@ -24,7 +25,7 @@ server.use("/api/v1/test", (_, res) => {
 });
 
 server.use("/api/v1/admin", adminRouter);
-// server.use("/api/v1/user", generalRouter);
+server.use("/api/v1/user", generalRouter);
 // server.use("/api/v1/mail", mailRouter);
 // server.use("/api/v1/event", eventRouter);
 

--- a/src/routes/admin.routes.ts
+++ b/src/routes/admin.routes.ts
@@ -1,4 +1,4 @@
-import { AdminLoginHandler, GetAllAdminHandler, CreateAdminHandler } from "@/controllers/admin/office";
+import { AdminLoginHandler, GetAllAdminHandler, CreateAdminHandler, GetPastAdminHandler } from "@/controllers/admin/office";
 import { Router } from "express";
 import { validateToken } from "@/middleware/authentication/token";
 import {
@@ -7,6 +7,7 @@ import {
   CreateEventHandler,
   EditEventHandler,
 } from "@/controllers/admin/event";
+import { GetAllBlogsHandlerForAdmin, GetBlogByIdHandler, UpdateBlogHandler, DeleteBlogHandler, ChangeStatusOfBlog} from "@/controllers/admin/blogs";
 
 const router = Router();
 
@@ -14,6 +15,7 @@ const router = Router();
 router.post("/office/login", AdminLoginHandler);
 // router.get("/office/dashboard", validateToken, AdminDashboardHandler);
 router.get("/office", validateToken, GetAllAdminHandler);
+router.get("/office/past", validateToken, GetPastAdminHandler);
 router.post("/office/new", validateToken, CreateAdminHandler);
 // router.post("/office/edit/{adminId}", validateToken, EditAdminHandler);
 
@@ -22,6 +24,14 @@ router.get("/events", validateToken, GetAllEventsHandler);
 router.get("/events/:eventId", validateToken, GetEventByIdHandler);
 router.post("/events/new", validateToken, CreateEventHandler);
 router.post("/events/edit/:eventId", validateToken, EditEventHandler);
+
+//Blogs
+router.get("/blogs", validateToken, GetAllBlogsHandlerForAdmin);
+router.get("/blogs/:blogId", validateToken, GetBlogByIdHandler);
+router.post("/blogs/update/:blogId", validateToken, UpdateBlogHandler);
+router.delete("/blogs/delete/:blogId", validateToken, DeleteBlogHandler);
+router.put("/blogs/UpdateStatus/:blogId", validateToken, ChangeStatusOfBlog);
+
   
 // Campaigns
 // router.get("/campaigns", validateToken, handleGetAllCampaigns);

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -1,13 +1,15 @@
 import { Router } from "express";
+import { GetAllBlogsHandlerForUser, GetBlogByIdHandler } from "@/controllers/user/blog";
 
 const router = Router();
 
 // router.post("/login", handleLogin);
 // router.post("/register", handleRegistration);
 // router.post("/register/otp", handleOTPVerification);
-//
-// router.get("/blog",)
-// router.get("/blog/:blogId",)
+
+//Blogs
+router.get("/blogs", GetAllBlogsHandlerForUser);
+router.get("/blogs/:blogId", GetBlogByIdHandler);
 //
 // router.get("/newsletter",)
 // router.get("/blog/:newsletterId",)

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const UpdateBlogValidator = z.object({
+    title : z.string().trim().min(3).regex(/^[a-zA-Z0-9_ ]+$/),
+    displayURL : z.string().url().optional(),
+    blurb : z.string().trim().min(3).regex(/^[a-zA-Z0-9_ ]+$/).optional(),
+    content : z.string().trim().min(3).regex(/^[a-zA-Z0-9_ ]+$/).optional(),
+    author : z.string().trim().min(3).regex(/^[a-zA-Z0-9_ ]+$/).optional(),
+    tags : z.array(z.string()),
+    status : z.enum(["Draft", "Published"]).default("Draft").optional(),
+    publishedOn : z.coerce.date().optional()
+})


### PR DESCRIPTION
### Blog and Admin API Handlers

#### Description
This PR adds several API handlers to manage blog content and retrieve past admin data. Key functionalities include creating, updating, deleting, and fetching blogs, along with fetching inactive admin details.

#### Changes
1. **Blog Handlers**
   - `GetBlogByIdHandler`: Fetch a blog by ID.
   - `GetAllBlogsHandlerForAdmin`: Get all blogs for admin view.
   - `GetAllBlogsHandlerForUser`: Fetch blogs for user.
   - `UpdateBlogHandler`: Update blog content.
   - `DeleteBlogHandler`: Delete a blog by ID.
   - `ChangeStatusOfBlog`: Update blog status to "Draft" or "Published".

2. **Admin Handler**
   - `GetPastAdminHandler`: Retrieve inactive admins with details
   
#### Completed issues : #20, #15